### PR TITLE
lua: execute idle handlers after timers have been processed

### DIFF
--- a/player/lua/defaults.lua
+++ b/player/lua/defaults.lua
@@ -476,12 +476,9 @@ function mp.dispatch_events(allow_wait)
     while mp.keep_running do
         local wait = 0
         if not more_events then
-            wait = process_timers()
-            if wait == nil then
-                for _, handler in ipairs(idle_handlers) do
-                    handler()
-                end
-                wait = 1e20 -- infinity for all practical purposes
+            wait = process_timers() or 1e20 -- infinity for all practical purposes
+            for _, handler in ipairs(idle_handlers) do
+                handler()
             end
             -- Resume playloop - important especially if an error happened while
             -- suspended, and the error was handled, but no resume was done.


### PR DESCRIPTION
Idle handlers used to not be executed when timers were active
Now they are executed:
* After all expired timers have been executed
* After all events have been processed (same as when there are no timers)

Ideally, you shouldn't need enter any text here, and your commit messages should
explain your changes sufficiently (especially why they are needed). Read
https://github.com/mpv-player/mpv/blob/master/DOCS/contribute.md for coding
style and development conventions. Remove this text block, but if you haven't
agreed to it before, leave the following sentence in place:

I agree that my changes can be relicensed to LGPL 2.1 or later.
