### PR TITLE
vd_lavc: increase the possible length of the hwdec name

### DIFF
--- a/video/decode/vd_lavc.c
+++ b/video/decode/vd_lavc.c
@@ -132,7 +132,7 @@ const struct m_sub_options vd_lavc_conf = {
 
 struct hwdec_info {
     char name[64];
-    char method_name[16]; // non-unique name describing the hwdec method
+    char method_name[24]; // non-unique name describing the hwdec method
     const AVCodec *codec; // implemented by this codec
     enum AVHWDeviceType lavc_device; // if not NONE, get a hwdevice
     bool copying; // if true, outputs sw frames, or copy to sw ourselves


### PR DESCRIPTION
this lead to an unexpected videotoolbox-copy hwdec name due to the last
two chars being cut off. since selection is also done by that name one
had to use "videotoolbox-co" to explicitly use the copy mode of
videotoolbox.

Ideally, you shouldn't need enter any text here, and your commit messages should
explain your changes sufficiently (especially why they are needed). Read
https://github.com/mpv-player/mpv/blob/master/DOCS/contribute.md for coding
style and development conventions. Remove this text block, but if you haven't
agreed to it before, leave the following sentence in place:

I agree that my changes can be relicensed to LGPL 2.1 or later.
