### PR TITLE
cocoa-cb: synchronise the flush with the render

### DIFF
--- a/osdep/macOS_mpv_helper.swift
+++ b/osdep/macOS_mpv_helper.swift
@@ -127,7 +127,7 @@ class MPVHelper: NSObject {
         return flags & UInt64(MPV_RENDER_UPDATE_FRAME.rawValue) > 0
     }
 
-    func drawRender(_ surface: NSSize, skip: Bool = false) {
+    func drawRender(_ surface: NSSize, _ ctx: CGLContextObj, skip: Bool = false) {
         deinitLock.lock()
         if mpvRenderContext != nil {
             var i: GLint = 0
@@ -153,6 +153,9 @@ class MPVHelper: NSObject {
             glClearColor(0, 0, 0, 1)
             glClear(GLbitfield(GL_COLOR_BUFFER_BIT))
         }
+
+        if !skip { CGLFlushDrawable(ctx) }
+
         deinitLock.unlock()
     }
 

--- a/video/out/cocoa-cb/video_layer.swift
+++ b/video/out/cocoa-cb/video_layer.swift
@@ -110,8 +110,7 @@ class VideoLayer: CAOpenGLLayer {
         }
 
         updateSurfaceSize()
-        mpv.drawRender(surfaceSize!)
-        CGLFlushDrawable(ctx)
+        mpv.drawRender(surfaceSize!, ctx)
 
         if needsICCUpdate {
             needsICCUpdate = false
@@ -244,7 +243,7 @@ class VideoLayer: CAOpenGLLayer {
         if isUpdate && needsFlip {
             CGLSetCurrentContext(cglContext!)
             if mpv.isRenderUpdateFrame() {
-                mpv.drawRender(NSZeroSize, skip: true)
+                mpv.drawRender(NSZeroSize, cglContext!, skip: true)
             }
         }
         displayLock.unlock()


### PR DESCRIPTION
this could lead to a crash on deinit when flush
was called while the opengl state was cleaned up.

Fixes #6323

Ideally, you shouldn't need enter any text here, and your commit messages should
explain your changes sufficiently (especially why they are needed). Read
https://github.com/mpv-player/mpv/blob/master/DOCS/contribute.md for coding
style and development conventions. Remove this text block, but if you haven't
agreed to it before, leave the following sentence in place:

I agree that my changes can be relicensed to LGPL 2.1 or later.
