### PR TITLE
command: remove the video-aspect property

### DIFF
--- a/DOCS/interface-changes.rst
+++ b/DOCS/interface-changes.rst
@@ -47,6 +47,11 @@ Interface changes
     - support for `--spirv-compiler=nvidia` has been removed, leaving `shaderc`
       as the only option. The `--spirv-compiler` option itself has been marked
       as deprecated, and may be removed in the future.
+    - remove the special-case for the option "video-aspect". When video-aspect
+      is set to "0" or "-1", it will actually return those values, rather than
+      turning this into the effective video aspect with those settings. If
+      you need access to the effective video aspect, you can e.g. divide
+      `video-out-params/dw` by `video-out-params/dh`.
  --- mpv 0.29.0 ---
     - drop --opensles-sample-rate, as --audio-samplerate should be used if desired
     - drop deprecated --videotoolbox-format, --ff-aid, --ff-vid, --ff-sid,

--- a/DOCS/man/input.rst
+++ b/DOCS/man/input.rst
@@ -1647,12 +1647,6 @@ Property list
 ``vsync-jitter``
     Estimated deviation factor of the vsync duration.
 
-``video-aspect`` (RW)
-    Video aspect, see ``--video-aspect``.
-
-    If video is active, this reports the effective aspect value, instead of
-    the value of the ``--video-aspect`` option.
-
 ``osd-width``, ``osd-height``
     Last known OSD width (can be 0). This is needed if you want to use the
     ``overlay-add`` command. It gives you the actual OSD size, which can be

--- a/player/command.c
+++ b/player/command.c
@@ -2995,44 +2995,6 @@ static int mp_property_vf_fps(void *ctx, struct m_property *prop,
     return m_property_double_ro(action, arg, 1.0 / avg);
 }
 
-/// Video aspect (RO)
-static int mp_property_aspect(void *ctx, struct m_property *prop,
-                              int action, void *arg)
-{
-    MPContext *mpctx = ctx;
-
-    float aspect = mpctx->opts->movie_aspect;
-    if (mpctx->vo_chain && aspect <= 0) {
-        struct mp_image_params *params = &mpctx->vo_chain->filter->input_params;
-        if (params && params->p_w > 0 && params->p_h > 0) {
-            int d_w, d_h;
-            mp_image_params_get_dsize(params, &d_w, &d_h);
-            aspect = (float)d_w / d_h;
-        }
-    }
-    struct track *track = mpctx->current_track[0][STREAM_VIDEO];
-    if (track && track->stream && aspect <= 0) {
-        struct mp_codec_params *c = track->stream->codec;
-        if (c->disp_w && c->disp_h)
-            aspect = (float)c->disp_w / c->disp_h;
-    }
-
-    switch (action) {
-    case M_PROPERTY_PRINT: {
-        if (mpctx->opts->movie_aspect < 0) {
-            *(char **)arg = talloc_asprintf(NULL, "%.3f (original)", aspect);
-            return M_PROPERTY_OK;
-        }
-        break;
-    }
-    case M_PROPERTY_GET: {
-        *(float *)arg = aspect;
-        return M_PROPERTY_OK;
-    }
-    }
-    return mp_property_generic_option(mpctx, prop, action, arg);
-}
-
 /// Selected subtitles (RW)
 static int mp_property_sub(void *ctx, struct m_property *prop,
                            int action, void *arg)
@@ -3952,7 +3914,6 @@ static const struct m_property mp_properties_base[] = {
     {"current-vo", mp_property_vo},
     {"container-fps", mp_property_fps},
     {"estimated-vf-fps", mp_property_vf_fps},
-    {"video-aspect", mp_property_aspect},
     {"vid", mp_property_video},
     {"program", mp_property_program},
     {"hwdec", mp_property_hwdec},


### PR DESCRIPTION
This property being special in the way it is broke use cases like
"cycle-values" with parameters including -1 or "no".

Unfortunately, this has the potential to break existing user scripts
which rely on the value of "video-aspect" to calculate the video aspect.
It doesn't seem like scripts actually use this value, but if this is
needed then we could introduce a new option in its place, preferably in
a place where it belongs more (like video-out-params).

User scripts can work around the lack of this option by doing e.g.
`video-out-params/dw` / `video-out-params/dh` (or ditto for
video-params) so I don't think this option having the special case it
does is that important.

Fixes #6068.

Ideally, you shouldn't need enter any text here, and your commit messages should
explain your changes sufficiently (especially why they are needed). Read
https://github.com/mpv-player/mpv/blob/master/DOCS/contribute.md for coding
style and development conventions. Remove this text block, but if you haven't
agreed to it before, leave the following sentence in place:

I agree that my changes can be relicensed to LGPL 2.1 or later.
