### PR TITLE
cocoa-cb: fix side by side Split View again

### DIFF
--- a/video/out/cocoa-cb/window.swift
+++ b/video/out/cocoa-cb/window.swift
@@ -300,6 +300,7 @@ class Window: NSWindow, NSWindowDelegate {
         let intermediateFrame = aspectFit(rect: newFrame, in: screen!.frame)
         cocoaCB.view.layerContentsPlacement = .scaleProportionallyToFill
         hideTitleBar()
+        styleMask.remove(.fullScreen)
         setFrame(intermediateFrame, display: true)
 
         NSAnimationContext.runAnimationGroup({ (context) -> Void in
@@ -435,9 +436,7 @@ class Window: NSWindow, NSWindowDelegate {
     }
 
     override func setFrame(_ frameRect: NSRect, display flag: Bool) {
-        let newFrame = !isAnimating && isInFullscreen ? targetScreen!.frame :
-                                                        frameRect
-        super.setFrame(newFrame, display: flag)
+        super.setFrame(frameRect, display: flag)
 
         if keepAspect {
             contentAspectRatio = unfsContentFrame!.size


### PR DESCRIPTION
some safety mechanism for the async fs animation aren't needed anymore,
due to possible improved logic and slightly different behaviour on new
macOS versions. that safety fallback prevented the Split View because
it always returned a rectangle of the whole screen, instead of just
part/half of it.

Fixes #6443

Ideally, you shouldn't need enter any text here, and your commit messages should
explain your changes sufficiently (especially why they are needed). Read
https://github.com/mpv-player/mpv/blob/master/DOCS/contribute.md for coding
style and development conventions. Remove this text block, but if you haven't
agreed to it before, leave the following sentence in place:

I agree that my changes can be relicensed to LGPL 2.1 or later.
