### PR TITLE
demux: support cue sheets longer than 100 minutes

### DIFF
--- a/demux/cue.c
+++ b/demux/cue.c
@@ -113,16 +113,17 @@ static struct bstr strip_quotes(struct bstr data)
     return data;
 }
 
-// Read a 2 digit unsigned decimal integer.
+// Read an unsigned decimal integer.
+// Optionally check if it is 2 digit.
 // Return -1 on failure.
-static int read_int_2(struct bstr *data)
+static int read_int(struct bstr *data, bool two_digit)
 {
     *data = bstr_lstrip(*data);
     if (data->len && data->start[0] == '-')
         return -1;
     struct bstr s = *data;
     int res = (int)bstrtoll(s, &s, 10);
-    if (data->len == s.len || data->len - s.len > 2)
+    if (data->len == s.len || (two_digit && data->len - s.len > 2))
         return -1;
     *data = s;
     return res;
@@ -132,11 +133,11 @@ static double read_time(struct bstr *data)
 {
     struct bstr s = *data;
     bool ok = true;
-    double t1 = read_int_2(&s);
+    double t1 = read_int(&s, false);
     ok = eat_char(&s, ':') && ok;
-    double t2 = read_int_2(&s);
+    double t2 = read_int(&s, true);
     ok = eat_char(&s, ':') && ok;
-    double t3 = read_int_2(&s);
+    double t3 = read_int(&s, true);
     ok = ok && t1 >= 0 && t2 >= 0 && t3 >= 0;
     return ok ? t1 * 60.0 + t2 + t3 * SECS_PER_CUE_FRAME : 0;
 }
@@ -205,7 +206,7 @@ struct cue_file *mp_parse_cue(struct bstr data)
             break;
         }
         case CUE_INDEX: {
-            int type = read_int_2(&param);
+            int type = read_int(&param, true);
             double time = read_time(&param);
             if (cur_track) {
                 if (type == 1) {


### PR DESCRIPTION
Remove the 2-digit-number restriction when reading the number of
minutes in the cue sheet INDEX command.

Fixes #6481

Ideally, you shouldn't need enter any text here, and your commit messages should
explain your changes sufficiently (especially why they are needed). Read
https://github.com/mpv-player/mpv/blob/master/DOCS/contribute.md for coding
style and development conventions. Remove this text block, but if you haven't
agreed to it before, leave the following sentence in place:

I agree that my changes can be relicensed to LGPL 2.1 or later.
