### PR TITLE
sub: recognize UTF-8 characters in SDH subtitle filter

### DIFF
--- a/sub/filter_sdh.c
+++ b/sub/filter_sdh.c
@@ -406,8 +406,11 @@ char *filter_SDH(struct sd *sd, char *format, int n_ignored, char *data, int len
                     line_with_text =  true;
                 }
             } else if (*rp && rp[0] != '\\') {
-                if (rp[0] > 32 && rp[0] < 127 && rp[0] != '-')
+                if ((rp[0] > 32 && rp[0] < 127 && rp[0] != '-') ||
+                    (unsigned char)rp[0] >= 0xC0)
+                {
                     line_with_text =  true;
+                }
                 append(sd, buf, rp[0]);
                 rp++;
             } else if (rp[0] == '\\' && rp[1] != 'N') {


### PR DESCRIPTION
Only printable ASCII characters were considered to be valid texts. Make
it possible that UTF-8 contents are also considered valid.

This does not make the SDH subtitle filter support non-English
languages. This just prevents the filter from blindly marking lines that
have only UTF-8 characters as empty.

Fixes #6502

Ideally, you shouldn't need enter any text here, and your commit messages should
explain your changes sufficiently (especially why they are needed). Read
https://github.com/mpv-player/mpv/blob/master/DOCS/contribute.md for coding
style and development conventions. Remove this text block, but if you haven't
agreed to it before, leave the following sentence in place:

I agree that my changes can be relicensed to LGPL 2.1 or later.
