### PR TITLE
player: fix core activity state check

### DIFF
--- a/player/playloop.c
+++ b/player/playloop.c
@@ -128,7 +128,7 @@ void update_core_idle_state(struct MPContext *mpctx)
     bool eof = mpctx->video_status == STATUS_EOF &&
                mpctx->audio_status == STATUS_EOF;
     bool active = !mpctx->paused && mpctx->restart_complete &&
-                  mpctx->stop_play && mpctx->in_playloop && !eof;
+                  !mpctx->stop_play && mpctx->in_playloop && !eof;
 
     if (mpctx->playback_active != active) {
         mpctx->playback_active = active;


### PR DESCRIPTION
Adds the negation missed in 8816e1117ee65039dbb5700219ba3537d3e5290e
when moving from a positive-is-active to positive-is-idle variable.

This leads to proper updates to properties such as "eof-reached",
as well as fixes screensaver state updates.

Separately found and fixed by avih and wnoun.

Co-authored-by: wnoun <wnoun@outlook.com>

Ideally, you shouldn't need enter any text here, and your commit messages should
explain your changes sufficiently (especially why they are needed). Read
https://github.com/mpv-player/mpv/blob/master/DOCS/contribute.md for coding
style and development conventions. Remove this text block, but if you haven't
agreed to it before, leave the following sentence in place:

I agree that my changes can be relicensed to LGPL 2.1 or later.
